### PR TITLE
chore: enable automerge in Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "automerge": false,
+  "automerge": true,
   "automergeStrategy": "squash",
   "extends": [
     "config:recommended",


### PR DESCRIPTION
This pull request includes a small but significant change to the `.github/renovate.json` file. The change enables automatic merging of pull requests by setting the `automerge` option to `true`.

* [`.github/renovate.json`](diffhunk://#diff-f82f7d36a61d22f640c25bdb8b0435bf9cb38679d99d5f460753fa668ee7cdb3L3-R3): Changed `automerge` from `false` to `true` to enable automatic merging of pull requests.